### PR TITLE
Make sure we ignore specific known patterns like bugsnag and rails logger

### DIFF
--- a/lib/extract_i18n.rb
+++ b/lib/extract_i18n.rb
@@ -17,8 +17,8 @@ module ExtractI18n
   self.strip_path = %r{^app/(javascript|controllers|views)|^lib|^src|^app}
 
   # ignore for .rb files: ignore those file types
-  self.ignore_hash_keys = %w[class_name foreign_key join_table association_foreign_key key]
-  self.ignore_functions = %w[where order group select sql]
+  self.ignore_hash_keys = %w[class_name foreign_key join_table association_foreign_key key msg event_name]
+  self.ignore_functions = %w[where order group select sql render notify]
   self.ignorelist = [
     '_',
     '::',

--- a/lib/extract_i18n/adapters/ruby_adapter.rb
+++ b/lib/extract_i18n/adapters/ruby_adapter.rb
@@ -122,7 +122,21 @@ module ExtractI18n::Adapters
       node.children[1] == :require ||
         node.type == :regexp ||
         (node.type == :pair && ExtractI18n.ignore_hash_keys.include?(node.children[0].children[0].to_s)) ||
-        (node.type == :send && ExtractI18n.ignore_functions.include?(node.children[1].to_s))
+        (node.type == :send && ExtractI18n.ignore_functions.include?(node.children[1].to_s)) ||
+        (node.type == :send &&
+          node.children[0] &&
+          node.children[0].type == :send &&
+          # Rails.logger methods should be ignored
+          # also ignores logger.info variations
+          node.children[0].children[1].to_s == 'logger'
+        ) ||
+        (node.type == :send &&
+          node.children[0] &&
+          node.children[0].type == :const &&
+          # RuntimeError means bugsnag so check parent for ignoring
+          node.children[0].children[1].to_s == 'RuntimeError' &&
+          @nesting[-3] && ignore_parent?(@nesting[-3])
+        )
     end
   end
 end


### PR DESCRIPTION
Asana Task: **https://app.asana.com/0/1202700403502936/1203793835420786/f**

Ignore render calls
Ignore bugsnag notify
Ignore any metric event with the event_name parameter 
Ignore any rails.logger calls

Add :msg and :event_name hash keys to ignored ones. Checked all of the files in elaine with these hash keys and saw that msg only occurred in Rails.logger calls and event_name was only in different metric values, this is an easy way to ignore all of those. 

Add render and notify to ignored functions, notify is only for bugsnag and render is for rendering a view, which we don't want translated.

Add two new cases to the ignore_parent? check. The first one handles Rails.logger without the msg hash key.  The second one ignores the Bugsnag.Notify. All of the bugsnag notify (that have strings in them) have a runtime error so we check for that then check the parents parent, which gets ignored because of the notify function being ignored