### PR TITLE
Ignore _t calls and nested description in _t calls

### DIFF
--- a/lib/extract_i18n.rb
+++ b/lib/extract_i18n.rb
@@ -18,7 +18,7 @@ module ExtractI18n
 
   # ignore for .rb files: ignore those file types
   self.ignore_hash_keys = %w[class_name foreign_key join_table association_foreign_key key msg event_name]
-  self.ignore_functions = %w[where order group select sql render notify]
+  self.ignore_functions = %w[where order group select sql render notify _t]
   self.ignorelist = [
     '_',
     '::',

--- a/lib/extract_i18n/adapters/ruby_adapter.rb
+++ b/lib/extract_i18n/adapters/ruby_adapter.rb
@@ -122,6 +122,11 @@ module ExtractI18n::Adapters
       node.children[1] == :require ||
         node.type == :regexp ||
         (node.type == :pair && ExtractI18n.ignore_hash_keys.include?(node.children[0].children[0].to_s)) ||
+        (node.type == :pair &&
+          node.children[0].children[0].to_s == 'description' &&
+          # Look up to possible _t function call
+          @nesting[-4] && ignore_parent?(@nesting[-4])
+        ) ||
         (node.type == :send && ExtractI18n.ignore_functions.include?(node.children[1].to_s)) ||
         (node.type == :send &&
           node.children[0] &&


### PR DESCRIPTION
Asana Task: **https://app.asana.com/0/1202700403502936/1203793835420791/f**

This makes sure we ignore already wrapped strings with _t