### PR TITLE
Adding blank description as part of the CLI

### DIFF
--- a/lib/extract_i18n/source_change.rb
+++ b/lib/extract_i18n/source_change.rb
@@ -29,7 +29,7 @@ module ExtractI18n
       source_line:,
       remove:,
       # we are using our own _t method by default
-      t_template: %{_t("%s"%s)},
+      t_template: %{_t("%s"%s, description: '')},
       interpolation_type: :ruby
     )
       @i18n_string = i18n_string
@@ -50,7 +50,7 @@ module ExtractI18n
       end
       if @source_line[@remove]
         s += PASTEL.cyan("with:     ") + PASTEL.blue(@source_line).
-          gsub(@remove, PASTEL.green(i18n_t))
+             gsub(@remove, PASTEL.green(i18n_t))
       else
         s += PASTEL.cyan("with:     ") + PASTEL.green(i18n_t)
       end
@@ -68,12 +68,6 @@ module ExtractI18n
                  else
                    key
                  end
-      # let's not have dangling commas for strings with no arguments
-      @t_template = if i18n_arguments_string.length > 0
-                      %{_t("%s"%s)}
-                    else
-                      %{_t("%s")}
-                    end
       sprintf(@t_template, i18n_key, i18n_arguments_string)
     end
 


### PR DESCRIPTION
Adding a blank description when wrapping the strings to reduce our overhead when using this tool

![iTerm - mattviele@YLW294GR9Q-~-repos-extract_i18n 2023-02-23 at 12 01 48 PM](https://user-images.githubusercontent.com/28240841/221018215-7036d86d-6e5d-4ec1-a0f3-1d688a9cd1b5.gif)
